### PR TITLE
Fix Mapbox view recreation error

### DIFF
--- a/passport/lib/my_trips_section.dart
+++ b/passport/lib/my_trips_section.dart
@@ -51,6 +51,7 @@ class _MyTripsSectionState extends State<MyTripsSection> {
 
   late MapManager mapManager;
   bool isMapInitialized = false;
+  final Key _mapKey = UniqueKey();
 
   @override
   void initState() {
@@ -310,7 +311,7 @@ class _MyTripsSectionState extends State<MyTripsSection> {
     return Stack(
       children: [
         MapWidget(
-          key: const ValueKey('unique_map_widget'),
+          key: _mapKey,
           cameraOptions: CameraOptions(
             center: Point(coordinates: Position(0, 0)),
             zoom: 2.0,


### PR DESCRIPTION
## Summary
- ensure MapWidget is created with a unique key per screen instance

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e2ae969988327801ee947e080f868