### PR TITLE
Adjust trip end logic

### DIFF
--- a/passport/lib/classes.dart
+++ b/passport/lib/classes.dart
@@ -3,11 +3,13 @@ class Location {
   final double latitude;
   final double longitude;
   final String timestamp;
+  final City? city;
 
   Location({
     required this.latitude,
     required this.longitude,
     required this.timestamp,
+    this.city,
   });
 
   Map<String, dynamic> toMap() {
@@ -15,6 +17,7 @@ class Location {
       'latitude': latitude,
       'longitude': longitude,
       'timestamp': timestamp,
+      'city': city?.name,
     };
   }
 }


### PR DESCRIPTION
## Summary
- fetch hometown list when building trips
- mark photos taken in a hometown so they break trips and are skipped
- refactor trip creation to end a trip when returning home or after a **3-day** gap
- store city info directly inside the `Location` class

## Testing
- `dart format passport/lib/user_data/data_operations.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e281d0c908327ae448637bb67cd8f